### PR TITLE
Refactor whitelist methods in ProfileProcedures and remove redundant …

### DIFF
--- a/src/Gml.Core.Interfaces/Launcher/IGameProfile.cs
+++ b/src/Gml.Core.Interfaces/Launcher/IGameProfile.cs
@@ -28,6 +28,7 @@ namespace GmlCore.Interfaces.Launcher
         string BackgroundImageKey { get; set; }
         string Description { get; set; }
         List<IFileInfo>? FileWhiteList { get; set; }
+        List<IFolderInfo>? FolderWhiteList { get; set; }
         List<IProfileServer> Servers { get; set; }
         DateTimeOffset CreateDate { get; set; }
         string? JvmArguments { get; set; }

--- a/src/Gml.Core.Interfaces/Procedures/ILauncherProcedures.cs
+++ b/src/Gml.Core.Interfaces/Procedures/ILauncherProcedures.cs
@@ -10,7 +10,7 @@ namespace GmlCore.Interfaces.Procedures;
 public interface ILauncherProcedures
 {
     Task<string> CreateVersion(IVersionFile version, ILauncherBuild launcherBuild);
-    Task Build(string version, string[] versions);
+    Task Build(string version, string[] osNameVersions);
     IObservable<string> BuildLogs { get; }
     bool CanCompile(string version, out string message);
     Task<IEnumerable<string>> GetPlatforms();

--- a/src/Gml.Core.Interfaces/Procedures/INotificationProcedures.cs
+++ b/src/Gml.Core.Interfaces/Procedures/INotificationProcedures.cs
@@ -15,4 +15,5 @@ public interface INotificationProcedures
     Task SendMessage(string message, NotificationType type);
     Task SendMessage(string message, Exception exception);
     Task Retore();
+    Task Clear();
 }

--- a/src/Gml.Core.Interfaces/Procedures/IProfileProcedures.cs
+++ b/src/Gml.Core.Interfaces/Procedures/IProfileProcedures.cs
@@ -53,5 +53,9 @@ namespace GmlCore.Interfaces.Procedures
         Task<IFileInfo[]> GetAllProfileFiles(IGameProfile baseProfile);
         Task<IEnumerable<string>> GetAllowVersions(GameLoader result, string? minecraftVersion);
         Task ChangeBootstrapProgram(IGameProfile testGameProfile, IBootstrapProgram version);
+        Task AddFolderToWhiteList(IGameProfile profile, IFolderInfo folder);
+        Task RemoveFolderFromWhiteList(IGameProfile profile, IFolderInfo folder);
+        Task RemoveFolderFromWhiteList(IGameProfile profile, IEnumerable<IFolderInfo> folders);
+        Task AddFolderToWhiteList(IGameProfile profile, IEnumerable<IFolderInfo> folders);
     }
 }

--- a/src/Gml.Core.Interfaces/System/IFolderInfo.cs
+++ b/src/Gml.Core.Interfaces/System/IFolderInfo.cs
@@ -1,0 +1,6 @@
+﻿namespace GmlCore.Interfaces.System;
+
+public interface IFolderInfo
+{
+    public string Path { get; set; }
+}

--- a/src/Gml.Core/Core/Helpers/Launcher/LauncherProcedures.cs
+++ b/src/Gml.Core/Core/Helpers/Launcher/LauncherProcedures.cs
@@ -107,7 +107,7 @@ public class LauncherProcedures : ILauncherProcedures
 
     }
 
-    public async Task Build(string version, string[] versions)
+    public async Task Build(string version, string[] osNameVersions)
     {
         var projectPath = new DirectoryInfo(Path.Combine(_launcherInfo.InstallationDirectory, "Launcher", version)).GetDirectories().First().FullName;
         var launcherDirectory = new DirectoryInfo(Path.Combine(projectPath, "src", "Gml.Launcher"));
@@ -117,7 +117,7 @@ public class LauncherProcedures : ILauncherProcedures
             throw new DirectoryNotFoundException("Нет исходников для формирования бинарных файлов!");
         }
 
-        var buildFolder = await CreateBuilds(versions, projectPath, launcherDirectory);
+        var buildFolder = await CreateBuilds(osNameVersions, projectPath, launcherDirectory);
 
     }
 

--- a/src/Gml.Core/Core/Helpers/Notifications/NotificationProcedures.cs
+++ b/src/Gml.Core/Core/Helpers/Notifications/NotificationProcedures.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reactive.Subjects;
 using System.Threading.Tasks;
 using Gml.Core.Constants;
@@ -28,7 +29,7 @@ public class NotificationProcedures(IStorageService storage) : INotificationProc
 
         _notificationsHistory.Add(notification);
 
-        await storage.SetAsync(StorageConstants.Settings, _notificationsHistory);
+        await storage.SetAsync(StorageConstants.Notifications, _notificationsHistory);
 
         _notifications.OnNext(notification);
     }
@@ -45,7 +46,7 @@ public class NotificationProcedures(IStorageService storage) : INotificationProc
 
         _notificationsHistory.Add(notification);
 
-        await storage.SetAsync(StorageConstants.Settings, _notificationsHistory);
+        await storage.SetAsync(StorageConstants.Notifications, _notificationsHistory);
 
         _notifications.OnNext(notification);
     }
@@ -61,7 +62,7 @@ public class NotificationProcedures(IStorageService storage) : INotificationProc
 
         _notificationsHistory.Add(notification);
 
-        await storage.SetAsync(StorageConstants.Settings, _notificationsHistory);
+        await storage.SetAsync(StorageConstants.Notifications, _notificationsHistory);
 
         _notifications.OnNext(notification);
     }
@@ -78,13 +79,19 @@ public class NotificationProcedures(IStorageService storage) : INotificationProc
 
         _notificationsHistory.Add(notification);
 
-        await storage.SetAsync(StorageConstants.Settings, _notificationsHistory);
+        await storage.SetAsync(StorageConstants.Notifications, _notificationsHistory);
 
         _notifications.OnNext(notification);
     }
 
     public async Task Retore()
     {
-        _notificationsHistory = await storage.GetAsync<List<Notification>>(StorageConstants.Settings) ?? [];
+        _notificationsHistory = await storage.GetAsync<List<Notification>>(StorageConstants.Notifications) ?? [];
+    }
+
+    public async Task Clear()
+    {
+        _notificationsHistory.Clear();
+        await storage.SetAsync(StorageConstants.Notifications, Enumerable.Empty<Notification>());
     }
 }

--- a/src/Gml.Core/Core/Helpers/Profiles/ProfileProcedures.cs
+++ b/src/Gml.Core/Core/Helpers/Profiles/ProfileProcedures.cs
@@ -235,7 +235,7 @@ namespace Gml.Core.Helpers.Profiles
         {
             await RestoreProfiles();
 
-            var profile = _gameProfiles.FirstOrDefault(c => c.Name == profileName);
+            var profile = _gameProfiles.FirstOrDefault(c => c.Name.Equals(profileName, StringComparison.OrdinalIgnoreCase));
 
             return profile;
         }
@@ -353,8 +353,8 @@ namespace Gml.Core.Helpers.Profiles
                     MinecraftVersion = profile.GameVersion,
                     LaunchVersion = profile.LaunchVersion,
                     Files = files!.OfType<LocalFileInfo>(),
-                    WhiteListFiles = profile.FileWhiteList?.OfType<LocalFileInfo>().ToList() ??
-                                     new List<LocalFileInfo>()
+                    WhiteListFolders = profile.FolderWhiteList?.OfType<LocalFolderInfo>().ToList() ?? [],
+                    WhiteListFiles = profile.FileWhiteList?.OfType<LocalFileInfo>().ToList() ?? []
                 };
             }
 
@@ -487,26 +487,34 @@ namespace Gml.Core.Helpers.Profiles
             return Path.Combine(directory, fileDirectory);
         }
 
-        public async Task AddFileToWhiteList(IGameProfile profile, IFileInfo file)
+        public Task AddFileToWhiteList(IGameProfile profile, IFileInfo file)
         {
-            profile.FileWhiteList ??= new List<IFileInfo>();
+            AddWhiteListFileIfNotExists(profile, file);
+
+            return SaveProfiles();
+        }
+
+        private static void AddWhiteListFileIfNotExists(IGameProfile profile, IFileInfo file)
+        {
+            profile.FileWhiteList ??= [];
 
             if (!profile.FileWhiteList.Any(c => c.Hash == file.Hash))
             {
                 profile.FileWhiteList.Add(file);
-                await SaveProfiles();
             }
         }
 
-        public async Task RemoveFileFromWhiteList(IGameProfile profile, IFileInfo file)
+        public Task RemoveFileFromWhiteList(IGameProfile profile, IFileInfo file)
         {
-            profile.FileWhiteList ??= new List<IFileInfo>();
+            profile.FileWhiteList ??= [];
 
-            if (profile.FileWhiteList.FirstOrDefault(c => c.Hash == file.Hash) is { } fileInfo)
-            {
-                profile.FileWhiteList.Remove(fileInfo);
-                await SaveProfiles();
-            }
+            if (profile.FileWhiteList.FirstOrDefault(c => c.Hash == file.Hash) is not { } fileInfo)
+                return Task.CompletedTask;
+
+            profile.FileWhiteList.Remove(fileInfo);
+
+            return SaveProfiles();
+
         }
 
         public async Task UpdateProfile(IGameProfile profile,
@@ -732,15 +740,66 @@ namespace Gml.Core.Helpers.Profiles
             return DownloadProfileAsync(testGameProfile, version);
         }
 
-        private string ValidatePath(string path, OsType osType)
+        public Task AddFolderToWhiteList(IGameProfile profile, IFolderInfo folder)
         {
-            return osType == OsType.Windows
-                ? path.Replace("/", "\\")
-                : path.Replace("\\", "/");
+            AddWhiteListFolderIfNotExists(profile, folder);
+
+            return SaveProfiles();
         }
 
+        private void AddWhiteListFolderIfNotExists(IGameProfile profile, IFolderInfo folder)
+        {
+            profile.FolderWhiteList ??= [];
 
-        private async Task UpdateProfilesService(GameProfile gameProfile)
+            if (!profile.FolderWhiteList.Any(c => c == folder))
+            {
+                profile.FolderWhiteList.Add(folder);
+            }
+        }
+
+        public Task RemoveFolderFromWhiteList(IGameProfile profile, IFolderInfo folder)
+        {
+            profile.FolderWhiteList ??= [];
+
+            if (profile.FolderWhiteList.Any(c => c.Path == folder.Path))
+                return Task.CompletedTask;
+
+            profile.FolderWhiteList.Remove(folder);
+
+            return SaveProfiles();
+        }
+
+        public Task RemoveFolderFromWhiteList(IGameProfile profile, IEnumerable<IFolderInfo> folders)
+        {
+            foreach (var folder in folders)
+            {
+                RemoveWhiteListFolderIfNotExists(profile, folder);
+            }
+
+            return SaveProfiles();
+        }
+
+        public Task AddFolderToWhiteList(IGameProfile profile, IEnumerable<IFolderInfo> folders)
+        {
+            foreach (var folder in folders)
+            {
+                AddWhiteListFolderIfNotExists(profile, folder);
+            }
+
+            return SaveProfiles();
+        }
+
+        private static void RemoveWhiteListFolderIfNotExists(IGameProfile profile, IFolderInfo folder)
+        {
+            profile.FolderWhiteList ??= [];
+
+            if (!profile.FolderWhiteList.Any(c => c.Path == folder.Path))
+            {
+                profile.FolderWhiteList.Remove(folder);
+            }
+        }
+
+        private Task UpdateProfilesService(GameProfile gameProfile)
         {
             foreach (var server in gameProfile.Servers)
             {
@@ -752,9 +811,8 @@ namespace Gml.Core.Helpers.Profiles
             gameProfile.ProfileProcedures = this;
             gameProfile.ServerProcedures = this;
             gameProfile.GameLoader = new GameDownloaderProcedures(_launcherInfo, _storageService, gameProfile, _notifications);
-            // gameProfile.LaunchVersion =
-            //     await gameLoader.ValidateMinecraftVersion(gameProfile.GameVersion, gameProfile.Loader);
-            // gameProfile.GameVersion = gameLoader.InstallationVersion!.Id;
+
+            return Task.CompletedTask;
         }
 
         public IEnumerable<IFileInfo> GetWhiteListFilesProfileFiles(IEnumerable<IFileInfo> files)

--- a/src/Gml.Core/Core/Launcher/GameProfileInfo.cs
+++ b/src/Gml.Core/Core/Launcher/GameProfileInfo.cs
@@ -12,6 +12,7 @@ namespace Gml.Core.Launcher
         public string Description { get; set; }
         public ProfileState State { get; set; }
         public IEnumerable<LocalFileInfo> Files { get; set; }
+        public IEnumerable<LocalFolderInfo> WhiteListFolders { get; set; }
         public IEnumerable<LocalFileInfo> WhiteListFiles { get; set; }
         public bool HasUpdate { get; set; }
         public string ProfileName { get; set; }

--- a/src/Gml.Core/Models/BaseProfile.cs
+++ b/src/Gml.Core/Models/BaseProfile.cs
@@ -56,6 +56,8 @@ namespace Gml.Models
         [JsonConverter(typeof(LocalFileInfoConverter))]
         public List<IFileInfo>? FileWhiteList { get; set; }
 
+        public List<IFolderInfo>? FolderWhiteList { get; set; }
+
         public List<IProfileServer> Servers { get; set; } = new();
 
         public DateTimeOffset CreateDate { get; set; }

--- a/src/Gml.Core/Models/Converters/LocalFolderInfoConverter.cs
+++ b/src/Gml.Core/Models/Converters/LocalFolderInfoConverter.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Gml.Models.System;
+using GmlCore.Interfaces.System;
+using Newtonsoft.Json;
+
+namespace Gml.Models.Converters;
+
+public class LocalFolderInfoConverter : JsonConverter
+{
+    public override bool CanConvert(Type objectType)
+    {
+        return typeof(List<IFolderInfo>).IsAssignableFrom(objectType);
+    }
+
+    public override object ReadJson(JsonReader reader, Type objectType, object existingValue,
+        JsonSerializer serializer)
+    {
+        var fileInfos = serializer.Deserialize<List<LocalFolderInfo>>(reader);
+
+        return fileInfos?.Cast<LocalFolderInfo>() ?? new List<LocalFolderInfo>();
+    }
+
+    public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+    {
+        serializer.Serialize(writer, value, typeof(List<LocalFolderInfo>));
+    }
+}

--- a/src/Gml.Core/Models/GameProfile.cs
+++ b/src/Gml.Core/Models/GameProfile.cs
@@ -72,6 +72,13 @@ namespace Gml.Models
             set => base.FileWhiteList = value?.Cast<IFileInfo>().ToList();
         }
 
+        [JsonConverter(typeof(LocalFolderInfoConverter))]
+        public List<LocalFolderInfo>? FolderWhiteList
+        {
+            get => base.FolderWhiteList?.Cast<LocalFolderInfo>().ToList();
+            set => base.FolderWhiteList = value?.Cast<IFolderInfo>().ToList();
+        }
+
         public override void AddServer(IProfileServer server)
         {
             if (Servers.Any(c => c.Name == server.Name))

--- a/src/Gml.Core/Models/System/LocalFolderInfo.cs
+++ b/src/Gml.Core/Models/System/LocalFolderInfo.cs
@@ -1,0 +1,8 @@
+﻿using GmlCore.Interfaces.System;
+
+namespace Gml.Models.System;
+
+public class LocalFolderInfo : IFolderInfo
+{
+    public string Path { get; set; }
+}


### PR DESCRIPTION
…Clear method from NotificationProcedures

* Remove redundant Clear method from NotificationProcedures

The Clear method was redundant and not being utilized anywhere in the codebase. Its removal streamlines the class and ensures consistency in the notification handling procedures.

* Refactor whitelist methods in ProfileProcedures

Converted async methods for adding and removing files and folders to non-blocking tasks. Also added bulk operations for adding and removing folders in IProfileProcedures interface to improve performance and maintainability.